### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,54 +1,54 @@
 FirstOrderFilter	KEYWORD1
-filter			KEYWORD2
-samplePeriod		KEYWORD2
-filterType		KEYWORD2
+filter	KEYWORD2
+samplePeriod	KEYWORD2
+filterType	KEYWORD2
 #
-Oscillator		KEYWORD1
-iterate			KEYWORD2
-setAmp			KEYWORD2
-setFreq			KEYWORD2
-getSin			KEYWORD2
-getCos			KEYWORD2
+Oscillator	KEYWORD1
+iterate	KEYWORD2
+setAmp	KEYWORD2
+setFreq	KEYWORD2
+getSin	KEYWORD2
+getCos	KEYWORD2
 #
-Biquad			KEYWORD1
-filter			KEYWORD2
+Biquad	KEYWORD1
+filter	KEYWORD2
 computeCoefficients KEYWORD2
-samplePeriod		KEYWORD2
-print			KEYWORD2
-LOWPASS			LITERAL1
-HIGHPASS		LITERAL1
-BANDPASS		LITERAL1
-NOTCH			LITERAL1
+samplePeriod	KEYWORD2
+print	KEYWORD2
+LOWPASS	LITERAL1
+HIGHPASS	LITERAL1
+BANDPASS	LITERAL1
+NOTCH	LITERAL1
 #
 StateVariableFilter	KEYWORD1
-filter			KEYWORD2
-samplePeriod		KEYWORD2
-setFrequency		KEYWORD2
-setQ			KEYWORD2
-getBP			KEYPWRD2
-getLP			KEYWORD2
-getHP			KEYWORD2
-getBR			KEYWORD2
+filter	KEYWORD2
+samplePeriod	KEYWORD2
+setFrequency	KEYWORD2
+setQ	KEYWORD2
+getBP	KEYPWRD2
+getLP	KEYWORD2
+getHP	KEYWORD2
+getBR	KEYWORD2
 #
 Halfband	KEYWORD1
-filter		KEYWORD2
+filter	KEYWORD2
 #
-Hilbert		KEYWORD1
-filter		KEYWORD2
-getI		KEYWORD2
-getQ		KEYWORD2
+Hilbert	KEYWORD1
+filter	KEYWORD2
+getI	KEYWORD2
+getQ	KEYWORD2
 #
-Integrator      KEYWORD1
-integrate       KEYWORD2
-reset           KEYWORD2
+Integrator	KEYWORD1
+integrate	KEYWORD2
+reset	KEYWORD2
 #
 Differentiator	KEYWORD1
 differentiate	KEYWORD2
 #
 #
 Delayline	KEYWORD1
-shiftIn		KEYWORD2
-getTap		KEYWORD2
+shiftIn	KEYWORD2
+getTap	KEYWORD2
 #
 
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords